### PR TITLE
Fix: Remove header HTML and clean up orphaned CSS rules

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,11 +28,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -122,27 +122,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -783,14 +762,6 @@ details[open] .suggested-header::before {
     
     .chat-main {
         order: 1;
-    }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .chat-messages {


### PR DESCRIPTION
Properly removes the `<header>` block from `index.html` entirely instead of hiding it via CSS. Also removes all orphaned CSS rules for `header`, `header h1`, `.subtitle`, and related media query styles.

Closes #2

Generated with [Claude Code](https://claude.ai/code)